### PR TITLE
Deprecate for Atom >= 0.193.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-package.json
 npm-debug.log

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-## Remember Session
+## Remember Session (Deprecated)
+
+*Deprecated as of Atom 0.193.0, as this functionality [has been added to Atom core](https://github.com/atom/atom/issues/1603#issuecomment-93599126) and will continue to be refined until 1.0*
 
 A simple package to save your session when you close Atom.  
 Based on

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/hampustagerud/atom-remember-session",
   "license": "MIT",
   "engines": {
-    "atom": ">0.50.0"
+    "atom": ">0.50.0 <0.193.0"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
https://github.com/atom/atom/issues/1603 has finally been implemented and will be released with Atom 0.193.0, so to avoid conflicts with this newly added core functionality, this PR deprecates Remember Session for Atom 0.193.0 and beyond.

:beers:
